### PR TITLE
revert back to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["USACE", "CWMS"]
 authors = ["Hydrologic Engineering Center"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 click = "^8.1.8"
 hecdss  = { version = ">=0.1.24", optional = true }  # Via https://github.com/HydrologicEngineeringCenter/hec-python-library/blob/main/hec/shared.py#L9-10
 cwms-python = { version = ">=0.8.0", optional = true}
@@ -29,12 +29,6 @@ pre-commit = "^3.6.2"
 #pytest-cov = "^4.1.0"
 #pandas-stubs = "^2.2.1.240316"
 yamlfix = "^1.16.0"
-
-
-[tool.poetry.group.docs.dependencies]
-sphinx = "^8.2.3"
-sphinx-rtd-theme = "^3.0.2"
-sphinx-click = "^6.1.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
read the docs packages should load from the requirement.txt file in the docs folder. and python version set from .readthedocs.yaml.