### PR TITLE
Add ignore for localhost/loopback to Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,4 +34,8 @@ intersphinx_mapping = {
 
 html_theme = "sphinx_rtd_theme"
 
+linkcheck_ignore = [
+    r"^http://localhost(:\d+)?/.*",
+    r"^http://127\.0\.0\.1(:\d+)?/.*",
+]
 # autodoc_mock_imports = ["cwms", "pandas", "requests"]


### PR DESCRIPTION
Ran Sphinx build/link checker locally with this setting in the config to confirm it ignores the localhost URLs

Did not bump verison, does not change source

#65 to prevent auto test build to pypi?