### PR TITLE
Add missing api key import for shef crit

### DIFF
--- a/cwmscli/commands/commands_cwms.py
+++ b/cwmscli/commands/commands_cwms.py
@@ -25,6 +25,7 @@ from cwmscli.utils.deps import requires
 @requires(reqs.cwms)
 def shefcritimport(filename, office, api_root, api_key, api_key_loc):
     from cwmscli.commands.shef_critfile_import import import_shef_critfile
+    from cwmscli.utils import get_api_key
 
     api_key = get_api_key(api_key, api_key_loc)
     import_shef_critfile(


### PR DESCRIPTION
Saw this was missing doing a side review of the state of things