### PR TITLE
Add documentation links to CLI Commands

### DIFF
--- a/cwmscli/utils/click_help.py
+++ b/cwmscli/utils/click_help.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Optional
 
 import click
 
@@ -22,7 +23,7 @@ def _render_version_line(ctx: click.Context) -> str:
     return f"Version: {colors.c(get_cwms_cli_version(), 'cyan', bright=True)}"
 
 
-def _docs_url_for_context(ctx: click.Context) -> str | None:
+def _docs_url_for_context(ctx: click.Context) -> Optional[str]:
     # Show docs links only on command root pages:
     # - cwms-cli --help (depth 1)
     # - cwms-cli <top-level-command> --help (depth 2)
@@ -40,8 +41,6 @@ def _docs_url_for_context(ctx: click.Context) -> str | None:
     command = (ctx.info_name or getattr(ctx.command, "name", None) or "").strip()
     page_map = {
         "blob": "blob",
-        "update": "update",
-        "version": "version",
     }
     # Link to dedicated pages that are created in \docs
     if command in page_map:
@@ -51,14 +50,14 @@ def _docs_url_for_context(ctx: click.Context) -> str | None:
     return f"{DOCS_BASE_URL}/cli.html#cwms-cli-{command}"
 
 
-def _render_docs_line(ctx: click.Context) -> str | None:
+def _render_docs_line(ctx: click.Context) -> Optional[str]:
     docs_url = _docs_url_for_context(ctx)
     if docs_url is None:
         return None
     return f"Docs: {colors.c(docs_url, 'blue', bright=True)}"
 
 
-def _inject_version_line(help_text: str, ctx: click.Context) -> str:
+def _inject_help_header(help_text: str, ctx: click.Context) -> str:
     lines = help_text.splitlines()
     if not lines:
         return help_text
@@ -83,14 +82,14 @@ def _inject_version_line(help_text: str, ctx: click.Context) -> str:
 def _wrap_get_help(command: click.Command) -> None:
     original_get_help = command.get_help
 
-    def get_help_with_version(ctx: click.Context) -> str:
-        return _inject_version_line(original_get_help(ctx), ctx)
+    def get_help_with_header(ctx: click.Context) -> str:
+        return _inject_help_header(original_get_help(ctx), ctx)
 
-    command.get_help = get_help_with_version  # type: ignore[method-assign]
+    command.get_help = get_help_with_header  # type: ignore[method-assign]
 
 
 def add_version_to_help_tree(command: click.Command) -> None:
-    """Patch a command tree so every help output shows the CLI version."""
+    """Patch a command tree so every help output shows the CLI version and docs link."""
     stack = [command]
     seen: set[int] = set()
 

--- a/tests/cli/test_all_commands_help.py
+++ b/tests/cli/test_all_commands_help.py
@@ -61,7 +61,6 @@ def test_every_command_has_help(runner, path, command):
     if len(path) == 1:
         page_map = {
             "blob": f"{DOCS_BASE_URL}/cli/blob.html",
-            "update": f"{DOCS_BASE_URL}/cli/update.html",
         }
         expected_docs = page_map.get(
             path[0], f"{DOCS_BASE_URL}/cli.html#cwms-cli-{path[0]}"


### PR DESCRIPTION
This will make it so our RTD that are generated either automatically via CLI lib or through our custom docs will be included in the commands. 

We need only make sure the root command matches the file name

i.e. `cwms-cli blob` matches `blob.rst` in the docs

Looks like this:
```bash
cwms-cli 
```
<img width="868" height="92" alt="image" src="https://github.com/user-attachments/assets/246c9885-63cc-44b6-8aaa-48695fb0e5c9" />

and

```bash
cwms-cli usgs
```

<img width="885" height="114" alt="image" src="https://github.com/user-attachments/assets/4b5dab9f-0d36-4201-8a4c-25c8dd961d97" />
