### PR TITLE
fix: validate blob list limits

### DIFF
--- a/cwmscli/commands/commands_cwms.py
+++ b/cwmscli/commands/commands_cwms.py
@@ -671,10 +671,15 @@ def update_cmd(**kwargs):
     show_default=True,
     help="Sort descending instead of ascending.",
 )
-@click.option("--limit", type=int, default=None, help="Max rows to show.")
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Max rows to show.",
+)
 @click.option(
     "--page-size",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Max rows to request from the blob endpoint. Defaults to --limit if set, otherwise no pagination (all results in one page).",
 )
@@ -837,10 +842,15 @@ def update_cmd(**kwargs):
     show_default=True,
     help="Sort descending instead of ascending.",
 )
-@click.option("--limit", type=int, default=None, help="Max rows to show.")
+@click.option(
+    "--limit",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Max rows to show.",
+)
 @click.option(
     "--page-size",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Max rows to request from the clob endpoint. Defaults to --limit when set.",
 )

--- a/tests/cli/test_blob_list_validation.py
+++ b/tests/cli/test_blob_list_validation.py
@@ -1,0 +1,60 @@
+from click.testing import CliRunner
+
+from cwmscli.__main__ import cli
+
+
+def test_blob_list_rejects_zero_limit():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "blob",
+            "list",
+            "--office",
+            "SWT",
+            "--api-root",
+            "https://example.test/cwms-data/",
+            "--limit",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--limit'" in result.output
+
+
+def test_blob_list_rejects_negative_page_size():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "blob",
+            "list",
+            "--office",
+            "SWT",
+            "--api-root",
+            "https://example.test/cwms-data/",
+            "--page-size",
+            "-1",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--page-size'" in result.output
+
+
+def test_clob_list_rejects_zero_limit():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "clob",
+            "list",
+            "--office",
+            "SWT",
+            "--api-root",
+            "https://example.test/cwms-data/",
+            "--limit",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--limit'" in result.output


### PR DESCRIPTION
## Summary
- require positive values for `cwms-cli blob list --limit` and `--page-size`
- apply the same validation to `cwms-cli clob list` for the matching options
- add CLI regression coverage for zero and negative values

Resolves #193

## Validation
- `poetry run pytest tests/cli/test_blob_list_validation.py -q`
- `poetry run pytest -q`
- `poetry check`