### PR TITLE
Add reproducible dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+ARG POETRY_VERSION=2.0.1
+
+ENV TZ=Etc/UTC \
+    VIRTUAL_ENV=/opt/venv \
+    POETRY_VIRTUALENVS_CREATE=false
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+RUN python -m venv "${VIRTUAL_ENV}" \
+    && "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir \
+        "poetry==${POETRY_VERSION}" \
+    && chown -R vscode:vscode "${VIRTUAL_ENV}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,11 +3,13 @@ FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
 ARG POETRY_VERSION=2.0.1
 
 ENV TZ=Etc/UTC \
-    VIRTUAL_ENV=/opt/venv \
+    POETRY_HOME=/opt/poetry \
+    VIRTUAL_ENV=/home/vscode/.venv \
     POETRY_VIRTUALENVS_CREATE=false
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV PATH="${VIRTUAL_ENV}/bin:${POETRY_HOME}/bin:${PATH}"
 
-RUN python -m venv "${VIRTUAL_ENV}" \
-    && "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir \
+RUN python -m venv "${POETRY_HOME}" \
+    && "${POETRY_HOME}/bin/python" -m pip install --no-cache-dir \
         "poetry==${POETRY_VERSION}" \
+    && python -m venv "${VIRTUAL_ENV}" \
     && chown -R vscode:vscode "${VIRTUAL_ENV}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "cwms-cli",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "POETRY_VERSION": "2.0.1"
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "TZ": "Etc/UTC",
+    "VIRTUAL_ENV": "/opt/venv",
+    "POETRY_VIRTUALENVS_CREATE": "false"
+  },
+  "postCreateCommand": "git config --global --add safe.directory \"$(pwd)\" && poetry install --with dev --no-interaction",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/venv/bin/python"
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
   "remoteUser": "vscode",
   "containerEnv": {
     "TZ": "Etc/UTC",
-    "VIRTUAL_ENV": "/opt/venv",
+    "POETRY_HOME": "/opt/poetry",
+    "VIRTUAL_ENV": "/home/vscode/.venv",
     "POETRY_VIRTUALENVS_CREATE": "false"
   },
   "postCreateCommand": "git config --global --add safe.directory \"$(pwd)\" && poetry install --with dev --no-interaction",
@@ -19,7 +20,7 @@
         "ms-python.python"
       ],
       "settings": {
-        "python.defaultInterpreterPath": "/opt/venv/bin/python"
+        "python.defaultInterpreterPath": "/home/vscode/.venv/bin/python"
       }
     }
   }

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -5,23 +5,18 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    name: Test CLI on ${{ matrix.python-version }}
+  test-python-39:
+    name: Test CLI on 3.9
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        # Test 3.9 for T7, 3.12 for general/cloud use
-        python-version: ["3.9", "3.12"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v4
@@ -33,8 +28,21 @@ jobs:
         run: poetry install --with dev --no-interaction
 
       - name: Smoke-test CLI on Python 3.9
-        if: matrix.python-version == '3.9'
         run: poetry run python scripts/smoke_test_cli.py
 
       - name: Run full test suite
         run: poetry run pytest -q
+
+  test-python-312:
+    name: Test CLI on 3.12
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Build dev container and run tests
+        uses: devcontainers/ci@v0.3
+        with:
+          push: never
+          runCmd: poetry run pytest -q

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -5,18 +5,23 @@ on:
     branches: [main]
 
 jobs:
-  test-python-39:
-    name: Test CLI on 3.9
+  test:
+    name: Test CLI on ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Test 3.9 for T7, 3.12 for general/cloud use
+        python-version: ["3.9", "3.12"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v4
@@ -28,13 +33,14 @@ jobs:
         run: poetry install --with dev --no-interaction
 
       - name: Smoke-test CLI on Python 3.9
+        if: matrix.python-version == '3.9'
         run: poetry run python scripts/smoke_test_cli.py
 
       - name: Run full test suite
         run: poetry run pytest -q
 
-  test-python-312:
-    name: Test CLI on 3.12
+  test-devcontainer:
+    name: Test dev container on 3.12
     runs-on: ubuntu-latest
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,14 @@
 - Never push to `origin` unless the user explicitly says they are ready for
   that push.
 - Never name branches `codex` or use `codex` as a branch-name prefix.
-- Use JDK 21 at `C:\Program Files\Java\jdk-21` unless a task specifically needs
-  another Java version.
+- Use JDK 21 or newer for new work that is not intended to run on T7 systems.
+  On Windows, use JDK 21 at `C:\Program Files\Java\jdk-21`. On Linux or other
+  Unix-like systems, select an installed JDK 21 or newer through `JAVA_HOME`.
+  Use another Java version only when the target or task requires it.
 - Use the `.devcontainer` Linux/Python 3.12 environment for changes involving
   time zones, paths, native libraries, HEC-DSS, or other operating-system-
   dependent behavior.
-- Run the full primary CI suite with
+- Run the full dev-container test suite with
   `devcontainer exec --workspace-folder . poetry run pytest -q` when the dev
-  container is available. Keep Python 3.9 compatibility considerations
-  separate from the primary Python 3.12 environment.
+  container is available. The standard CI matrix separately covers Python 3.9
+  and Python 3.12 package compatibility.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,6 @@
 
 - Never push to `origin` unless the user explicitly says they are ready for
   that push.
-- Never name branches `codex` or use `codex` as a branch-name prefix.
 - Use JDK 21 or newer for new work that is not intended to run on T7 systems.
   On Windows, use JDK 21 at `C:\Program Files\Java\jdk-21`. On Linux or other
   Unix-like systems, select an installed JDK 21 or newer through `JAVA_HOME`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository instructions
+
+- Never push to `origin` unless the user explicitly says they are ready for
+  that push.
+- Never name branches `codex` or use `codex` as a branch-name prefix.
+- Use JDK 21 at `C:\Program Files\Java\jdk-21` unless a task specifically needs
+  another Java version.
+- Use the `.devcontainer` Linux/Python 3.12 environment for changes involving
+  time zones, paths, native libraries, HEC-DSS, or other operating-system-
+  dependent behavior.
+- Run the full primary CI suite with
+  `devcontainer exec --workspace-folder . poetry run pytest -q` when the dev
+  container is available. Keep Python 3.9 compatibility considerations
+  separate from the primary Python 3.12 environment.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,20 @@ from cwmscli.usgs.getusgs_cda import getusgs_cda
 from cwmscli.usgs.getusgs_measurements_cda import getusgs_measurements_cda
 from cwmscli.usgs.getUSGS_ratings_cda import getusgs_rating_cda
 ```
+
+## Development environment
+
+The repository includes a Linux/Python 3.12 development container matching the
+primary CI test environment. Open the repository with the VS Code Dev
+Containers extension, or use the Dev Container CLI:
+
+```sh
+devcontainer up --workspace-folder .
+devcontainer exec --workspace-folder . poetry run pytest -q
+```
+
+The container installs project dependencies with Poetry and uses
+`/opt/venv`, so it does not reuse a host operating system's `.venv`. Use the
+container for changes involving time zones, paths, native libraries, or other
+operating-system-dependent behavior. Python 3.9 compatibility remains covered
+by a separate CI job.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ devcontainer exec --workspace-folder . poetry run pytest -q
 ```
 
 The container installs project dependencies with Poetry and uses
-`/opt/venv`, so it does not reuse a host operating system's `.venv`. Use the
-container for changes involving time zones, paths, native libraries, or other
+`/home/vscode/.venv`, so it does not reuse a host operating system's `.venv`.
+Poetry itself is kept in a separate `/opt/poetry` environment. Use the container
+for changes involving time zones, paths, native libraries, or other
 operating-system-dependent behavior. Python 3.9 compatibility remains covered
 by a separate CI job.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ from cwmscli.usgs.getUSGS_ratings_cda import getusgs_rating_cda
 
 ## Development environment
 
-The repository includes a Linux/Python 3.12 development container matching the
-primary CI test environment. Open the repository with the VS Code Dev
-Containers extension, or use the Dev Container CLI:
+The repository includes a Linux/Python 3.12 development container exercised by
+a dedicated CI job. Open the repository with the VS Code Dev Containers
+extension, or use the Dev Container CLI:
 
 ```sh
 devcontainer up --workspace-folder .
@@ -56,5 +56,5 @@ The container installs project dependencies with Poetry and uses
 `/home/vscode/.venv`, so it does not reuse a host operating system's `.venv`.
 Poetry itself is kept in a separate `/opt/poetry` environment. Use the container
 for changes involving time zones, paths, native libraries, or other
-operating-system-dependent behavior. Python 3.9 compatibility remains covered
-by a separate CI job.
+operating-system-dependent behavior. Standard Python 3.9 and Python 3.12
+installations remain covered by the existing CI matrix.


### PR DESCRIPTION
## Summary
- add a Linux/Python 3.12 development container
- run Python 3.12 CI through the same container while retaining Python 3.9 coverage
- document contributor and agent usage

## Validation
- `poetry run pytest -q` in the dev container (225 passed)
- `poetry run pre-commit run --all-files` in the dev container
