### PR TITLE
fix: show update environment before confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ Or as of version `0.3.0+`
 cwms-cli update
 ```
 
-`cwms-cli update` displays the Python executable, environment, and package
-location it will update before asking for confirmation. It runs pip through the
-same Python interpreter that is running `cwms-cli`, avoiding accidental updates
-to a different Python installation or virtual environment.
+`cwms-cli update` displays the Python executable, environment, package metadata
+location, and editable project location when applicable before asking for
+confirmation. It runs pip through the same Python interpreter that is running
+`cwms-cli`, avoiding accidental updates to a different Python installation or
+virtual environment.
 
 To install a specific version:
 ```sh

--- a/README.md
+++ b/README.md
@@ -14,13 +14,18 @@ Note: You may need to run `python -m pip install cwms-cli` if PIP is not in your
 
 ### Update
 ```sh
-pip install cwms-cli --upgrade
+python -m pip install --upgrade cwms-cli
 ```
 
 Or as of version `0.3.0+`
 ```sh
 cwms-cli update
 ```
+
+`cwms-cli update` displays the Python executable, environment, and package
+location it will update before asking for confirmation. It runs pip through the
+same Python interpreter that is running `cwms-cli`, avoiding accidental updates
+to a different Python installation or virtual environment.
 
 To install a specific version:
 ```sh

--- a/cwmscli/commands/commands_cwms.py
+++ b/cwmscli/commands/commands_cwms.py
@@ -435,7 +435,12 @@ def update_cli_cmd(target_version: Optional[str], pre: bool, yes: bool) -> None:
         f"  Environment: {update_environment.environment_prefix} "
         f"({update_environment.environment_type})"
     )
-    click.echo(f"  Package location: {update_environment.package_location}")
+    click.echo(f"  Package metadata location: {update_environment.package_location}")
+    if update_environment.editable_project_location:
+        click.echo(
+            "  Editable project location: "
+            f"{update_environment.editable_project_location}"
+        )
 
     cmd = [
         update_environment.python_executable,

--- a/cwmscli/commands/commands_cwms.py
+++ b/cwmscli/commands/commands_cwms.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import subprocess
-import sys
 import textwrap
 from pathlib import Path
 from typing import Optional
@@ -26,6 +25,7 @@ from cwmscli.utils.auth import DEFAULT_REDIRECT_HOST, DEFAULT_REDIRECT_PORT
 from cwmscli.utils.deps import requires
 from cwmscli.utils.update import (
     build_update_package_spec,
+    get_update_environment,
     launch_windows_update,
     looks_like_missing_version,
 )
@@ -416,6 +416,7 @@ def csv2cwms_cmd(**kwargs):
 def update_cli_cmd(target_version: Optional[str], pre: bool, yes: bool) -> None:
     current_version = get_cwms_cli_version()
     package_spec = build_update_package_spec(target_version)
+    update_environment = get_update_environment()
 
     click.echo(
         "Current cwms-cli version: " f"{colors.c(current_version, 'cyan', bright=True)}"
@@ -428,12 +429,30 @@ def update_cli_cmd(target_version: Optional[str], pre: bool, yes: bool) -> None:
     else:
         click.echo("Requested cwms-cli version: latest available release")
 
-    cmd = [sys.executable, "-m", "pip", "install", "--upgrade", package_spec]
+    click.echo("Update environment:")
+    click.echo(f"  Python executable: {update_environment.python_executable}")
+    click.echo(
+        f"  Environment: {update_environment.environment_prefix} "
+        f"({update_environment.environment_type})"
+    )
+    click.echo(f"  Package location: {update_environment.package_location}")
+
+    cmd = [
+        update_environment.python_executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        package_spec,
+    ]
     if pre:
         cmd.append("--pre")
 
     if not yes:
-        proceed = click.confirm("Proceed with updating cwms-cli via pip?", default=True)
+        proceed = click.confirm(
+            "Proceed with updating cwms-cli in this environment via pip?",
+            default=True,
+        )
         if not proceed:
             click.echo(colors.warn("Update canceled."))
             return

--- a/cwmscli/commands/commands_cwms.py
+++ b/cwmscli/commands/commands_cwms.py
@@ -27,6 +27,7 @@ from cwmscli.utils.update import (
     build_update_package_spec,
     get_update_environment,
     launch_windows_update,
+    looks_like_externally_managed_environment,
     looks_like_missing_version,
 )
 from cwmscli.utils.version import get_cwms_cli_version
@@ -496,6 +497,16 @@ def update_cli_cmd(target_version: Optional[str], pre: bool, yes: bool) -> None:
 
     if result.returncode != 0:
         pip_output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+        if looks_like_externally_managed_environment(pip_output):
+            raise click.ClickException(
+                colors.err(
+                    "The selected Python installation is externally managed, so pip "
+                    "refused to update cwms-cli. Install cwms-cli in a virtual "
+                    "environment or with pipx, then run that installation's "
+                    "cwms-cli update command. cwms-cli will not use "
+                    "--break-system-packages automatically."
+                )
+            )
         if target_version and looks_like_missing_version(pip_output, package_spec):
             raise click.ClickException(
                 colors.err(

--- a/cwmscli/utils/update.py
+++ b/cwmscli/utils/update.py
@@ -1,10 +1,13 @@
 import importlib.metadata
+import json
 import os
 import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
 from typing import List, Optional
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
 
 
 @dataclass(frozen=True)
@@ -13,6 +16,7 @@ class UpdateEnvironment:
     environment_prefix: str
     environment_type: str
     package_location: str
+    editable_project_location: Optional[str] = None
 
 
 def _absolute_path(path: str) -> str:
@@ -23,6 +27,37 @@ def _same_path(left: str, right: str) -> bool:
     return os.path.normcase(_absolute_path(left)) == os.path.normcase(
         _absolute_path(right)
     )
+
+
+def _editable_project_location(
+    distribution: importlib.metadata.Distribution,
+) -> Optional[str]:
+    direct_url_text = distribution.read_text("direct_url.json")
+    if not direct_url_text:
+        return None
+
+    try:
+        direct_url = json.loads(direct_url_text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    if not isinstance(direct_url, dict):
+        return None
+    directory_info = direct_url.get("dir_info")
+    if not isinstance(directory_info, dict) or not directory_info.get("editable"):
+        return None
+
+    url = direct_url.get("url")
+    if not isinstance(url, str):
+        return None
+    parsed_url = urlparse(url)
+    if parsed_url.scheme != "file":
+        return None
+
+    project_path = url2pathname(unquote(parsed_url.path))
+    if parsed_url.netloc and parsed_url.netloc != "localhost":
+        project_path = f"//{parsed_url.netloc}{project_path}"
+    return _absolute_path(project_path)
 
 
 def get_update_environment() -> UpdateEnvironment:
@@ -41,17 +76,20 @@ def get_update_environment() -> UpdateEnvironment:
     try:
         distribution = importlib.metadata.distribution("cwms-cli")
         package_location = os.path.realpath(os.fspath(distribution.locate_file("")))
+        editable_project_location = _editable_project_location(distribution)
     except importlib.metadata.PackageNotFoundError:
         # This can happen when the CLI is invoked directly from a source checkout.
         package_location = os.path.dirname(
             os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         )
+        editable_project_location = None
 
     return UpdateEnvironment(
         python_executable=python_executable,
         environment_prefix=environment_prefix,
         environment_type=environment_type,
         package_location=package_location,
+        editable_project_location=editable_project_location,
     )
 
 

--- a/cwmscli/utils/update.py
+++ b/cwmscli/utils/update.py
@@ -106,6 +106,10 @@ def looks_like_missing_version(pip_output: str, package_spec: str) -> bool:
     ) and package_spec in pip_output
 
 
+def looks_like_externally_managed_environment(pip_output: str) -> bool:
+    return "externally-managed-environment" in pip_output.lower()
+
+
 def write_windows_update_script(cmd: List[str]) -> str:
     quoted_cmd = subprocess.list2cmdline(cmd)
     script = "\r\n".join(

--- a/cwmscli/utils/update.py
+++ b/cwmscli/utils/update.py
@@ -1,6 +1,58 @@
+import importlib.metadata
+import os
 import subprocess
+import sys
 import tempfile
+from dataclasses import dataclass
 from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class UpdateEnvironment:
+    python_executable: str
+    environment_prefix: str
+    environment_type: str
+    package_location: str
+
+
+def _absolute_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def _same_path(left: str, right: str) -> bool:
+    return os.path.normcase(_absolute_path(left)) == os.path.normcase(
+        _absolute_path(right)
+    )
+
+
+def get_update_environment() -> UpdateEnvironment:
+    """Describe the Python environment targeted by ``cwms-cli update``."""
+    python_executable = _absolute_path(sys.executable)
+    environment_prefix = _absolute_path(sys.prefix)
+    conda_prefix = os.getenv("CONDA_PREFIX")
+
+    if conda_prefix and _same_path(conda_prefix, sys.prefix):
+        environment_type = "Conda environment"
+    elif not _same_path(sys.prefix, sys.base_prefix):
+        environment_type = "virtual environment"
+    else:
+        environment_type = "Python installation"
+
+    try:
+        distribution = importlib.metadata.distribution("cwms-cli")
+        package_location = os.path.realpath(os.fspath(distribution.locate_file("")))
+    except importlib.metadata.PackageNotFoundError:
+        # This can happen when the CLI is invoked directly from a source checkout.
+        package_location = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+
+    return UpdateEnvironment(
+        python_executable=python_executable,
+        environment_prefix=environment_prefix,
+        environment_type=environment_type,
+        package_location=package_location,
+    )
 
 
 def build_update_package_spec(target_version: Optional[str]) -> str:

--- a/docs/cli/update.rst
+++ b/docs/cli/update.rst
@@ -8,8 +8,23 @@ By default it installs the latest available release, and you can optionally
 target a specific version with ``--target-version``. After updating, use
 :doc:`Version argument <version>` to confirm the installed version.
 
+Before asking for confirmation, the command displays the Python executable,
+environment prefix and type, and package location that will be updated. The
+update runs pip through that displayed executable (``python -m pip``), so it
+targets the same Python environment that is running ``cwms-cli``. This is
+especially useful when multiple Python installations or virtual environments
+are present.
+
 On Windows, the command launches the pip install in a separate command window so
 the running ``cwms-cli.exe`` does not block its own replacement.
+
+.. note::
+
+   A standalone ``pip install --upgrade cwms-cli`` command uses whichever
+   ``pip`` executable appears first on the shell's path, which may belong to a
+   different Python environment. Prefer ``cwms-cli update``. When updating
+   manually, use the full Python executable displayed by ``cwms-cli update``
+   with ``-m pip install --upgrade cwms-cli``.
 
 Examples
 --------

--- a/docs/cli/update.rst
+++ b/docs/cli/update.rst
@@ -27,6 +27,22 @@ the running ``cwms-cli.exe`` does not block its own replacement.
    manually, use the full Python executable displayed by ``cwms-cli update``
    with ``-m pip install --upgrade cwms-cli``.
 
+Linux externally managed environments
+-------------------------------------
+
+Some Linux distributions mark their system Python installation as externally
+managed under PEP 668. If pip reports ``externally-managed-environment``,
+``cwms-cli update`` explains that the selected Python installation cannot be
+changed safely and recommends installing ``cwms-cli`` in a virtual environment
+or with pipx. The updater does not automatically pass
+``--break-system-packages``, because doing so can conflict with packages managed
+by the operating system.
+
+A correctly created virtual environment is not subject to the system Python's
+externally managed restriction. Confirm that the displayed Python executable
+and environment prefix both point into the intended virtual environment before
+continuing.
+
 Editable installations
 ----------------------
 

--- a/docs/cli/update.rst
+++ b/docs/cli/update.rst
@@ -9,11 +9,12 @@ target a specific version with ``--target-version``. After updating, use
 :doc:`Version argument <version>` to confirm the installed version.
 
 Before asking for confirmation, the command displays the Python executable,
-environment prefix and type, and package location that will be updated. The
-update runs pip through that displayed executable (``python -m pip``), so it
-targets the same Python environment that is running ``cwms-cli``. This is
-especially useful when multiple Python installations or virtual environments
-are present.
+environment prefix and type, and installed package metadata location. For an
+editable installation, it also displays the editable project location recorded
+by the installer. The update runs pip through the displayed executable
+(``python -m pip``), so it targets the same Python environment that is running
+``cwms-cli``. This is especially useful when multiple Python installations or
+virtual environments are present.
 
 On Windows, the command launches the pip install in a separate command window so
 the running ``cwms-cli.exe`` does not block its own replacement.
@@ -25,6 +26,14 @@ the running ``cwms-cli.exe`` does not block its own replacement.
    different Python environment. Prefer ``cwms-cli update``. When updating
    manually, use the full Python executable displayed by ``cwms-cli update``
    with ``-m pip install --upgrade cwms-cli``.
+
+Editable installations
+----------------------
+
+Editable installations keep their distribution metadata in the environment's
+``site-packages`` directory while loading source code from a project directory.
+The updater displays both paths when ``direct_url.json`` identifies the current
+installation as editable.
 
 Examples
 --------

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -147,6 +147,25 @@ def test_update_command_surfaces_missing_target_version(monkeypatch):
     assert "Requested cwms-cli version '9.9.9' was not found." in result.output
 
 
+def test_update_command_explains_externally_managed_environment(monkeypatch):
+    def fake_run(cmd, check=False, capture_output=False, text=False):
+        return _DummyResult(
+            1,
+            stderr="error: externally-managed-environment\n",
+        )
+
+    _set_update_os(monkeypatch, "posix")
+    monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["update", "--yes"])
+
+    assert result.exit_code == 1
+    assert "selected Python installation is externally managed" in result.output
+    assert "virtual environment or with pipx" in result.output
+    assert "will not use --break-system-packages automatically" in result.output
+
+
 def test_update_command_cancelled_by_user(monkeypatch):
     calls = []
 

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -1,4 +1,5 @@
 import sys
+from types import SimpleNamespace
 
 from click.testing import CliRunner
 
@@ -11,6 +12,11 @@ class _DummyResult:
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+
+
+def _set_update_os(monkeypatch, name):
+    """Set the updater OS without changing the process-wide ``os`` module."""
+    monkeypatch.setattr("cwmscli.commands.commands_cwms.os", SimpleNamespace(name=name))
 
 
 def test_update_command_runs_pip_upgrade(monkeypatch):
@@ -26,7 +32,7 @@ def test_update_command_runs_pip_upgrade(monkeypatch):
         calls.append((cmd, check, capture_output, text))
         return _DummyResult(0)
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
     monkeypatch.setattr(
         "cwmscli.commands.commands_cwms.get_cwms_cli_version", lambda: "1.2.3"
@@ -69,7 +75,7 @@ def test_update_command_includes_pre_flag(monkeypatch):
         calls.append((cmd, check, capture_output, text))
         return _DummyResult(0)
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
 
     runner = CliRunner()
@@ -86,7 +92,7 @@ def test_update_command_targets_specific_version(monkeypatch):
         calls.append((cmd, check, capture_output, text))
         return _DummyResult(0)
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
 
     runner = CliRunner()
@@ -108,7 +114,7 @@ def test_update_command_surfaces_pip_failure(monkeypatch):
     def fake_run(cmd, check=False, capture_output=False, text=False):
         return _DummyResult(1)
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
 
     runner = CliRunner()
@@ -129,7 +135,7 @@ def test_update_command_surfaces_missing_target_version(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
 
     runner = CliRunner()
@@ -146,7 +152,7 @@ def test_update_command_cancelled_by_user(monkeypatch):
         calls.append((cmd, check, capture_output, text))
         return _DummyResult(0)
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "posix")
+    _set_update_os(monkeypatch, "posix")
     monkeypatch.setattr("cwmscli.commands.commands_cwms.subprocess.run", fake_run)
 
     runner = CliRunner()
@@ -167,7 +173,7 @@ def test_update_command_defers_to_separate_process_on_windows(monkeypatch):
     def fake_run(*args, **kwargs):
         raise AssertionError("subprocess.run should not be used on Windows update")
 
-    monkeypatch.setattr("cwmscli.commands.commands_cwms.os.name", "nt")
+    _set_update_os(monkeypatch, "nt")
     monkeypatch.setattr(
         "cwmscli.commands.commands_cwms.launch_windows_update", fake_launch
     )

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -26,6 +26,7 @@ def test_update_command_runs_pip_upgrade(monkeypatch):
         environment_prefix=r"C:\Python",
         environment_type="Python installation",
         package_location=r"C:\Python\Lib\site-packages",
+        editable_project_location=r"C:\src\cwms-cli",
     )
 
     def fake_run(cmd, check=False, capture_output=False, text=False):
@@ -49,7 +50,8 @@ def test_update_command_runs_pip_upgrade(monkeypatch):
     assert "Current cwms-cli version: 1.2.3" in result.output
     assert "Python executable: C:\\Python\\python.exe" in result.output
     assert "Environment: C:\\Python (Python installation)" in result.output
-    assert "Package location: C:\\Python\\Lib\\site-packages" in result.output
+    assert "Package metadata location: C:\\Python\\Lib\\site-packages" in result.output
+    assert "Editable project location: C:\\src\\cwms-cli" in result.output
     assert result.output.index("Update environment:") < result.output.index(
         "Proceed with updating"
     )

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -3,6 +3,7 @@ import sys
 from click.testing import CliRunner
 
 from cwmscli.__main__ import cli
+from cwmscli.utils.update import UpdateEnvironment
 
 
 class _DummyResult:
@@ -14,6 +15,12 @@ class _DummyResult:
 
 def test_update_command_runs_pip_upgrade(monkeypatch):
     calls = []
+    update_environment = UpdateEnvironment(
+        python_executable=r"C:\Python\python.exe",
+        environment_prefix=r"C:\Python",
+        environment_type="Python installation",
+        package_location=r"C:\Python\Lib\site-packages",
+    )
 
     def fake_run(cmd, check=False, capture_output=False, text=False):
         calls.append((cmd, check, capture_output, text))
@@ -24,16 +31,26 @@ def test_update_command_runs_pip_upgrade(monkeypatch):
     monkeypatch.setattr(
         "cwmscli.commands.commands_cwms.get_cwms_cli_version", lambda: "1.2.3"
     )
+    monkeypatch.setattr(
+        "cwmscli.commands.commands_cwms.get_update_environment",
+        lambda: update_environment,
+    )
 
     runner = CliRunner()
     result = runner.invoke(cli, ["update"], input="y\n")
 
     assert result.exit_code == 0
     assert "Current cwms-cli version: 1.2.3" in result.output
+    assert "Python executable: C:\\Python\\python.exe" in result.output
+    assert "Environment: C:\\Python (Python installation)" in result.output
+    assert "Package location: C:\\Python\\Lib\\site-packages" in result.output
+    assert result.output.index("Update environment:") < result.output.index(
+        "Proceed with updating"
+    )
     assert "Update complete" in result.output
     assert len(calls) == 1
     assert calls[0][0] == [
-        sys.executable,
+        r"C:\Python\python.exe",
         "-m",
         "pip",
         "install",

--- a/tests/utils/test_update.py
+++ b/tests/utils/test_update.py
@@ -1,0 +1,63 @@
+import importlib.metadata
+import os
+
+from cwmscli.utils.update import get_update_environment
+
+
+class _Distribution:
+    def __init__(self, location):
+        self.location = location
+
+    def locate_file(self, path):
+        return self.location / path
+
+
+def test_get_update_environment_reports_virtual_environment(monkeypatch, tmp_path):
+    environment_prefix = tmp_path / "venv"
+    package_location = environment_prefix / "site-packages"
+    python_executable = environment_prefix / "bin" / "python"
+
+    monkeypatch.setattr("cwmscli.utils.update.sys.executable", str(python_executable))
+    monkeypatch.setattr("cwmscli.utils.update.sys.prefix", str(environment_prefix))
+    monkeypatch.setattr("cwmscli.utils.update.sys.base_prefix", str(tmp_path / "base"))
+    monkeypatch.delenv("CONDA_PREFIX", raising=False)
+    monkeypatch.setattr(
+        "cwmscli.utils.update.importlib.metadata.distribution",
+        lambda name: _Distribution(package_location),
+    )
+
+    details = get_update_environment()
+
+    assert details.python_executable == os.path.abspath(python_executable)
+    assert details.environment_prefix == os.path.abspath(environment_prefix)
+    assert details.environment_type == "virtual environment"
+    assert details.package_location == str(package_location.resolve())
+
+
+def test_get_update_environment_reports_conda_environment(monkeypatch, tmp_path):
+    environment_prefix = tmp_path / "conda-env"
+
+    monkeypatch.setattr("cwmscli.utils.update.sys.prefix", str(environment_prefix))
+    monkeypatch.setattr("cwmscli.utils.update.sys.base_prefix", str(tmp_path / "base"))
+    monkeypatch.setenv("CONDA_PREFIX", str(environment_prefix))
+    monkeypatch.setattr(
+        "cwmscli.utils.update.importlib.metadata.distribution",
+        lambda name: _Distribution(environment_prefix / "site-packages"),
+    )
+
+    details = get_update_environment()
+
+    assert details.environment_type == "Conda environment"
+
+
+def test_get_update_environment_falls_back_for_source_checkout(monkeypatch):
+    def missing_distribution(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(
+        "cwmscli.utils.update.importlib.metadata.distribution", missing_distribution
+    )
+
+    details = get_update_environment()
+
+    assert details.package_location.endswith("cwms-cli")

--- a/tests/utils/test_update.py
+++ b/tests/utils/test_update.py
@@ -1,15 +1,22 @@
 import importlib.metadata
+import json
 import os
 
 from cwmscli.utils.update import get_update_environment
 
 
 class _Distribution:
-    def __init__(self, location):
+    def __init__(self, location, direct_url=None):
         self.location = location
+        self.direct_url = direct_url
 
     def locate_file(self, path):
         return self.location / path
+
+    def read_text(self, filename):
+        if filename == "direct_url.json":
+            return self.direct_url
+        return None
 
 
 def test_get_update_environment_reports_virtual_environment(monkeypatch, tmp_path):
@@ -48,6 +55,39 @@ def test_get_update_environment_reports_conda_environment(monkeypatch, tmp_path)
     details = get_update_environment()
 
     assert details.environment_type == "Conda environment"
+
+
+def test_get_update_environment_reports_editable_project(monkeypatch, tmp_path):
+    environment_prefix = tmp_path / "venv"
+    package_location = environment_prefix / "site-packages"
+    project_location = tmp_path / "project with spaces"
+    direct_url = json.dumps(
+        {
+            "dir_info": {"editable": True},
+            "url": project_location.as_uri(),
+        }
+    )
+
+    monkeypatch.setattr(
+        "cwmscli.utils.update.importlib.metadata.distribution",
+        lambda name: _Distribution(package_location, direct_url),
+    )
+
+    details = get_update_environment()
+
+    assert details.package_location == str(package_location.resolve())
+    assert details.editable_project_location == os.path.abspath(project_location)
+
+
+def test_get_update_environment_ignores_invalid_direct_url(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "cwmscli.utils.update.importlib.metadata.distribution",
+        lambda name: _Distribution(tmp_path, "not json"),
+    )
+
+    details = get_update_environment()
+
+    assert details.editable_project_location is None
 
 
 def test_get_update_environment_falls_back_for_source_checkout(monkeypatch):


### PR DESCRIPTION
## Summary

- show the Python executable, environment prefix and type, and installed package location before updating
- run pip through the displayed interpreter so the update targets the environment running `cwms-cli`
- recognize standard Python, virtualenv, and Conda environments across Windows and POSIX
- document the safer `python -m pip` manual update form and the updater's environment behavior

## Root cause and impact

A bare `pip install` can resolve to a different Python installation from the one running `cwms-cli`. Although the updater already used the running interpreter, it did not expose that environment before asking for confirmation. Users can now verify the exact runtime and package location before any update begins.

## Validation

- `poetry run pytest -q` - 228 passed
- repository-pinned Black and isort checks
- ownership synchronization check
- CLI smoke test
- Sphinx HTML build with warnings treated as errors

Fixes #222
