### PR TITLE
ci: test CLI on Linux, Windows, and macOS

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -6,13 +6,27 @@ on:
 
 jobs:
   test:
-    name: Test CLI on ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Test CLI on ${{ matrix.name }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
-        # Test 3.9 for T7, 3.12 for general/cloud use
-        python-version: ["3.9", "3.12"]
+        include:
+          # Test the supported Python range on Linux and exercise the primary
+          # Python version on each supported desktop operating system.
+          - name: Linux
+            os: ubuntu-latest
+            python-version: "3.9"
+          - name: Linux
+            os: ubuntu-latest
+            python-version: "3.12"
+          - name: Windows
+            os: windows-latest
+            python-version: "3.12"
+          - name: macOS
+            os: macos-latest
+            python-version: "3.12"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
﻿## Summary

- expand CLI pull request testing from Linux-only to Linux, Windows, and macOS
- retain Python 3.9 and 3.12 coverage on Linux
- run Python 3.12 on Windows and macOS
- keep all matrix jobs running after one platform fails so platform-specific results are visible together

## Why

This follows up on Mitch's review comment in #246. The update command had been exercised locally on Windows and WSL, but Mitch encountered an `error: externally-managed-environment` failure in a native Linux virtual environment. That surfaced an important gap: behavior that looks correct in one local environment can still fail under another operating system's Python packaging rules.

Running the test suite on native GitHub-hosted Linux, Windows, and macOS runners should expose these cross-environment differences earlier in pull requests.

## Test matrix

| Operating system | Python |
| --- | --- |
| Linux | 3.9 |
| Linux | 3.12 |
| Windows | 3.12 |
| macOS | 3.12 |

Python 3.9 is tested only on Linux to provide the closest practical GitHub-hosted approximation for continued T7 support without multiplying every Python version across every operating system.

Solaris is not included because GitHub does not provide a hosted Solaris runner. Supporting it would require separately managed infrastructure rather than a standard Actions runner.

## Runtime impact

The four jobs run in parallel. Existing Linux jobs generally complete in under a minute, so this should increase total runner usage more than pull request wall-clock time. The matrix intentionally avoids the six-job full operating-system/Python cross-product.

## Validation

- parsed the updated workflow YAML and confirmed four matrix entries
- repository pre-commit checks passed, including `yamlfix`
- `poetry check` passed
- installed the project and development dependencies natively on Windows
- CLI smoke test passed
- full Windows test suite passed: 235 tests
