### PR TITLE
fix: refresh ownership metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,25 @@
 # Generated from maintainers.toml by scripts/sync_ownership.py.
 # Update maintainers.toml, then rerun the sync script.
 
-* charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Default owners for repository-wide files and shared cwms-cli behavior
+* charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Fallback owners for paths without a later, more specific rule; keep this rule first
 /.github/CODEOWNERS charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Protect ownership rules themselves
+/maintainers.toml charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Primary configuration file for ownership metadata
+/scripts/sync_ownership.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Ownership metadata generator
+/AGENTS.md charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Repository ownership maintenance guidance
 /cwmscli/commands/csv2cwms/ charles.r.graham@usace.army.mil
 /docs/cli/csv2cwms*.rst charles.r.graham@usace.army.mil
 /cwmscli/commands/blob.py charles.r.graham@usace.army.mil
 /docs/cli/blob.rst charles.r.graham@usace.army.mil
 /cwmscli/utils/update.py charles.r.graham@usace.army.mil
 /docs/cli/update.rst charles.r.graham@usace.army.mil
+/tests/cli/test_update_command.py charles.r.graham@usace.army.mil
 /cwmscli/load/ charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
 /docs/cli/load_*.rst charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
+/tests/load/ charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
+/tests/commands/test_load_*.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
 /cwmscli/usgs/ eric.v.novotny@usace.army.mil
-/cwmscli/commands/shef_critfile_import.py eric.v.novotny@usace.army.mil
+/tests/usgs/ eric.v.novotny@usace.army.mil
+/tests/cli/test_usgs_*.py eric.v.novotny@usace.army.mil
+/cwmscli/commands/shef/ eric.v.novotny@usace.army.mil
+/tests/commands/test_shef_*.py eric.v.novotny@usace.army.mil
 /cwmscli/commands/commands_cwms.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Shared Click wrappers span commands owned by both maintainers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,30 @@ Guidance for coding agents working in `HydrologicEngineeringCenter/cwms-cli`.
 - When testing colored output, cover the plain-text behavior first. Enable the
   shared color helper explicitly only in tests that need to assert escape codes,
   and restore its state afterward.
+
+## Ownership metadata
+
+- Use `maintainers.toml` as the primary configuration file for maintainer names,
+  CLI ownership, documentation maintainer notes, package authors, and
+  CODEOWNERS rules. Do not edit generated ownership files directly.
+- When adding, renaming, moving, or removing a command, implementation area,
+  documentation page, test area, workflow, or other substantial path, review
+  and update the corresponding entries in `maintainers.toml` in the same
+  change.
+- Keep the fallback `*` CODEOWNERS rule first. GitHub applies the last matching
+  rule, so more-specific rules must appear after the fallback.
+- Prefer explicit CODEOWNERS rules for implementation, documentation, and tests
+  that share the same maintainer. Keep ownership-governance files themselves
+  explicitly owned.
+- After changing `maintainers.toml`, run
+  `poetry run python scripts/sync_ownership.py`, review every generated change,
+  and then run `poetry run python scripts/sync_ownership.py --check`.
+- Before completing ownership changes, verify that configured command names and
+  CODEOWNERS paths still exist and that GitHub reports no CODEOWNERS errors.
+
+## Git safety
+
+- Never push to `origin` unless the user explicitly authorizes the push.
+- Do not use `codex`, `agent`, AI-related terms, or similar prefixes in branch
+  names. Use a short, human-readable branch name tied to the concern.
+- Inspect untracked files before staging and leave unrelated work untouched.

--- a/cwmscli/_generated/ownership_data.py
+++ b/cwmscli/_generated/ownership_data.py
@@ -25,7 +25,7 @@ OWNERSHIP_DATA = {
                 "name": "Eric Novotny"
             }
         ],
-        "cwms-cli shefcritimport": [
+        "cwms-cli shef": [
             {
                 "email": "eric.v.novotny@usace.army.mil",
                 "name": "Eric Novotny"

--- a/maintainers.toml
+++ b/maintainers.toml
@@ -18,7 +18,7 @@ default = ["charles", "eric"]
 "cwms-cli update" = ["charles"]
 "cwms-cli load" = ["charles", "eric"]
 "cwms-cli usgs" = ["eric"]
-"cwms-cli shefcritimport" = ["eric"]
+"cwms-cli shef" = ["eric"]
 
 [docs.pages]
 "cli" = "cwms-cli"
@@ -30,12 +30,27 @@ default = ["charles", "eric"]
 [[codeowners.rule]]
 pattern = "*"
 owners = ["charles", "eric"]
-comment = "Default owners for repository-wide files and shared cwms-cli behavior"
+comment = "Fallback owners for paths without a later, more specific rule; keep this rule first"
 
 [[codeowners.rule]]
 pattern = "/.github/CODEOWNERS"
 owners = ["charles", "eric"]
 comment = "Protect ownership rules themselves"
+
+[[codeowners.rule]]
+pattern = "/maintainers.toml"
+owners = ["charles", "eric"]
+comment = "Primary configuration file for ownership metadata"
+
+[[codeowners.rule]]
+pattern = "/scripts/sync_ownership.py"
+owners = ["charles", "eric"]
+comment = "Ownership metadata generator"
+
+[[codeowners.rule]]
+pattern = "/AGENTS.md"
+owners = ["charles", "eric"]
+comment = "Repository ownership maintenance guidance"
 
 [[codeowners.rule]]
 pattern = "/cwmscli/commands/csv2cwms/"
@@ -62,6 +77,10 @@ pattern = "/docs/cli/update.rst"
 owners = ["charles"]
 
 [[codeowners.rule]]
+pattern = "/tests/cli/test_update_command.py"
+owners = ["charles"]
+
+[[codeowners.rule]]
 pattern = "/cwmscli/load/"
 owners = ["charles", "eric"]
 
@@ -70,11 +89,31 @@ pattern = "/docs/cli/load_*.rst"
 owners = ["charles", "eric"]
 
 [[codeowners.rule]]
+pattern = "/tests/load/"
+owners = ["charles", "eric"]
+
+[[codeowners.rule]]
+pattern = "/tests/commands/test_load_*.py"
+owners = ["charles", "eric"]
+
+[[codeowners.rule]]
 pattern = "/cwmscli/usgs/"
 owners = ["eric"]
 
 [[codeowners.rule]]
-pattern = "/cwmscli/commands/shef_critfile_import.py"
+pattern = "/tests/usgs/"
+owners = ["eric"]
+
+[[codeowners.rule]]
+pattern = "/tests/cli/test_usgs_*.py"
+owners = ["eric"]
+
+[[codeowners.rule]]
+pattern = "/cwmscli/commands/shef/"
+owners = ["eric"]
+
+[[codeowners.rule]]
+pattern = "/tests/commands/test_shef_*.py"
 owners = ["eric"]
 
 [[codeowners.rule]]

--- a/tests/test_ownership_metadata.py
+++ b/tests/test_ownership_metadata.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.9/3.10
+    import tomli as tomllib
+
+from cwmscli.__main__ import cli
+from cwmscli._generated.ownership_data import OWNERSHIP_DATA
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _command_paths(command, path=("cwms-cli",)):
+    yield " ".join(path)
+    for name, subcommand in getattr(command, "commands", {}).items():
+        yield from _command_paths(subcommand, path + (name,))
+
+
+def test_configured_cli_ownership_references_live_commands():
+    live_commands = set(_command_paths(cli))
+    configured_commands = set(OWNERSHIP_DATA["commands"])
+
+    assert configured_commands <= live_commands, (
+        "Maintainer assignments reference commands that no longer exist: "
+        f"{sorted(configured_commands - live_commands)}"
+    )
+
+
+def test_codeowners_rules_reference_live_paths():
+    with (ROOT / "maintainers.toml").open("rb") as maintainers_file:
+        data = tomllib.load(maintainers_file)
+
+    dead_patterns = []
+    for rule in data["codeowners"]["rule"]:
+        pattern = rule["pattern"]
+        if pattern == "*":
+            continue
+
+        repository_pattern = pattern.lstrip("/").rstrip("/")
+        if not any(ROOT.glob(repository_pattern)):
+            dead_patterns.append(pattern)
+
+    assert not dead_patterns, (
+        "CODEOWNERS rules reference paths that no longer exist: " f"{dead_patterns}"
+    )


### PR DESCRIPTION
## Summary

- clarify that the leading wildcard is fallback ownership and keep specific rules later
- repair stale SHEF command and path ownership after the command-group refactor
- extend existing Update, Load, USGS, and SHEF ownership to their focused tests
- add repository guidance for keeping ownership metadata current
- add regression tests for removed command names and dead CODEOWNERS paths

## Why

Ownership metadata had drifted after `shefcritimport` became the `shef` command group and its implementation moved into `cwmscli/commands/shef/`. The generated files were internally synchronized, so the existing sync check could not detect those semantically stale entries.

## Impact

CODEOWNERS routing now follows the current repository layout, while Charles Graham and Eric Novotny remain fallback owners for paths without a later specific rule. Future command and path removals are checked in tests.

## Validation

- `poetry run python scripts/sync_ownership.py --check`
- `poetry run pytest tests/test_ownership_metadata.py tests/cli/test_all_commands_help.py -q` (45 passed)
- targeted pre-commit checks for all changed files
- `git diff --check`
