### PR TITLE
test: skip native DSS integration on macOS

### DIFF
--- a/docs/cli/dss.rst
+++ b/docs/cli/dss.rst
@@ -10,6 +10,10 @@ HEC-DSS support is optional:
 
    pip install "cwms-cli[dss]"
 
+The native ``hecdss`` library is not currently available in macOS Mach-O
+format. DSS file operations are therefore not supported on macOS, even though
+the rest of ``cwms-cli`` can run there.
+
 .. _dss-commands:
 
 Commands

--- a/docs/cli/dss.rst
+++ b/docs/cli/dss.rst
@@ -11,8 +11,7 @@ HEC-DSS support is optional:
    pip install "cwms-cli[dss]"
 
 The native ``hecdss`` library is not currently available in macOS Mach-O
-format. DSS file operations are therefore not supported on macOS, even though
-the rest of ``cwms-cli`` can run there.
+format. DSS file operations are therefore not supported on macOS.
 
 .. _dss-commands:
 

--- a/tests/dss/test_dss_integration.py
+++ b/tests/dss/test_dss_integration.py
@@ -1,9 +1,15 @@
+import sys
+
 import pytest
 
 from cwmscli.dss.naming import ExportRule, default_pathname
 from cwmscli.dss.transfer import DssSink, DssSource, transform_export
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="hecdss does not currently provide a macOS native library",
+)
 @pytest.mark.integration
 @pytest.mark.parametrize(
     ("tsid", "times", "dss_time_zone"),


### PR DESCRIPTION
## Summary

- skip the real native DSS round-trip integration test on macOS
- document that the bundled `hecdss` native library is not available in Mach-O format

## Why

The cross-platform matrix and DSS integration tests were merged independently. Their combination revealed that `hecdss` installs a Linux `libhecdss.so` on macOS, which fails to load because it is not a Mach-O library. Unit and mocked DSS tests remain enabled on macOS; only the native file round trip is skipped.

## Validation

- `poetry run pytest -q` (271 passed on Windows, including all three native DSS round trips)
- targeted pre-commit checks passed
- `poetry run sphinx-build -W -b html docs .tmp_docs_html`
- `git diff --check`
