### PR TITLE
feat: add dev helper script to preview docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /.github/CODEOWNERS charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Protect ownership rules themselves
 /maintainers.toml charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Primary configuration file for ownership metadata
 /scripts/sync_ownership.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Ownership metadata generator
+/scripts/preview_docs.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil mitchell.s.weier@usace.army.mil  # Local docs preview helper
 /AGENTS.md charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Repository ownership maintenance guidance
 /cwmscli/commands/csv2cwms/ charles.r.graham@usace.army.mil
 /docs/cli/csv2cwms*.rst charles.r.graham@usace.army.mil
@@ -18,6 +19,7 @@
 /docs/cli/load_*.rst charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
 /tests/load/ charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
 /tests/commands/test_load_*.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil
+/tests/test_preview_docs.py charles.r.graham@usace.army.mil eric.v.novotny@usace.army.mil  # Local docs preview helper tests
 /cwmscli/usgs/ eric.v.novotny@usace.army.mil
 /tests/usgs/ eric.v.novotny@usace.army.mil
 /tests/cli/test_usgs_*.py eric.v.novotny@usace.army.mil

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,20 @@ name: Docs Validation
 
 on:
   pull_request:
-    paths: ["docs/**", "cwmscli/**", "pyproject.toml"]
+    paths:
+      - "docs/**"
+      - "cwmscli/**"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "CONTRIBUTING.md"
   push:
     branches: [main]
-    paths: ["docs/**", "cwmscli/**", "pyproject.toml"]
+    paths:
+      - "docs/**"
+      - "cwmscli/**"
+      - "pyproject.toml"
+      - "scripts/**"
+      - "CONTRIBUTING.md"
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,25 @@ Ownership metadata is centralized in [maintainers.toml](/maintainers.toml).
 
 To run tests you can run: `poetry run pytest`
 
+## Preview Docs Locally
+
+Install the repo's development dependencies and the Sphinx docs dependencies:
+
+```sh
+poetry install --with dev --no-interaction
+python -m pip install -r docs/requirements.txt
+```
+
+Build and preview the docs locally before pushing:
+
+```sh
+python scripts/preview_docs.py
+```
+
+The helper runs the same warnings-as-errors HTML build used in CI, then serves
+`docs/_build/html` at `http://127.0.0.1:8000/`. Stop the preview server with
+`Ctrl-C`.
+
 ## Releases
 
 Releases are managed with `release-please`. Do not create releases or tags manually in the GitHub UI.

--- a/maintainers.toml
+++ b/maintainers.toml
@@ -6,6 +6,10 @@ email = "charles.r.graham@usace.army.mil"
 name = "Eric Novotny"
 email = "eric.v.novotny@usace.army.mil"
 
+[people.mitch]
+name = "Mitch Weier"
+email = "mitchell.s.weier@usace.army.mil"
+
 [poetry]
 authors = ["eric", "charles"]
 
@@ -46,6 +50,11 @@ comment = "Primary configuration file for ownership metadata"
 pattern = "/scripts/sync_ownership.py"
 owners = ["charles", "eric"]
 comment = "Ownership metadata generator"
+
+[[codeowners.rule]]
+pattern = "/scripts/preview_docs.py"
+owners = ["charles", "eric", "mitch"]
+comment = "Local docs preview helper"
 
 [[codeowners.rule]]
 pattern = "/AGENTS.md"
@@ -95,6 +104,11 @@ owners = ["charles", "eric"]
 [[codeowners.rule]]
 pattern = "/tests/commands/test_load_*.py"
 owners = ["charles", "eric"]
+
+[[codeowners.rule]]
+pattern = "/tests/test_preview_docs.py"
+owners = ["charles", "eric"]
+comment = "Local docs preview helper tests"
 
 [[codeowners.rule]]
 pattern = "/cwmscli/usgs/"

--- a/scripts/preview_docs.py
+++ b/scripts/preview_docs.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = ROOT / "docs"
+BUILD_DIR = DOCS_DIR / "_build" / "html"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DOCS_MODULES = ("sphinx", "sphinx_rtd_theme", "sphinx_click")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build and preview the cwms-cli docs locally."
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"Local port for the preview server (default: {DEFAULT_PORT}).",
+    )
+    return parser.parse_args(argv)
+
+
+def find_missing_docs_modules() -> list[str]:
+    return [name for name in DOCS_MODULES if importlib.util.find_spec(name) is None]
+
+
+def build_docs() -> int:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "sphinx",
+            "-nW",
+            "-b",
+            "html",
+            str(DOCS_DIR),
+            str(BUILD_DIR),
+        ],
+        cwd=ROOT,
+        check=False,
+    )
+    return result.returncode
+
+
+def serve_docs(port: int) -> None:
+    handler = partial(SimpleHTTPRequestHandler, directory=str(BUILD_DIR))
+    server = ThreadingHTTPServer((DEFAULT_HOST, port), handler)
+    print(f"Docs preview available at http://{DEFAULT_HOST}:{port}/")
+    print(f"Serving files from {BUILD_DIR}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping docs preview server.")
+    finally:
+        server.server_close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    missing = find_missing_docs_modules()
+    if missing:
+        missing_list = ", ".join(missing)
+        print(
+            "Missing docs dependencies "
+            f"({missing_list}). Install them with:\n"
+            f"{sys.executable} -m pip install -r docs/requirements.txt",
+            file=sys.stderr,
+        )
+        return 1
+
+    build_status = build_docs()
+    if build_status != 0:
+        return build_status
+
+    serve_docs(args.port)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_preview_docs.py
+++ b/tests/test_preview_docs.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "preview_docs.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("preview_docs", SCRIPT_PATH)
+preview_docs = importlib.util.module_from_spec(SCRIPT_SPEC)
+assert SCRIPT_SPEC.loader is not None
+SCRIPT_SPEC.loader.exec_module(preview_docs)
+
+
+def test_build_docs_uses_strict_sphinx_command(monkeypatch):
+    calls = {}
+
+    def fake_run(command, cwd, check):
+        calls["command"] = command
+        calls["cwd"] = cwd
+        calls["check"] = check
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(preview_docs.subprocess, "run", fake_run)
+
+    assert preview_docs.build_docs() == 0
+    assert calls["command"] == [
+        preview_docs.sys.executable,
+        "-m",
+        "sphinx",
+        "-nW",
+        "-b",
+        "html",
+        str(preview_docs.DOCS_DIR),
+        str(preview_docs.BUILD_DIR),
+    ]
+    assert calls["cwd"] == preview_docs.ROOT
+    assert calls["check"] is False
+
+
+def test_main_reports_missing_docs_dependencies(monkeypatch, capsys):
+    monkeypatch.setattr(
+        preview_docs.importlib.util,
+        "find_spec",
+        lambda name: None if name == "sphinx" else object(),
+    )
+    monkeypatch.setattr(
+        preview_docs,
+        "build_docs",
+        lambda: pytest.fail("build_docs should not run when deps are missing"),
+    )
+
+    assert preview_docs.main([]) == 1
+
+    captured = capsys.readouterr()
+    assert "Missing docs dependencies (sphinx)." in captured.err
+    assert "pip install -r docs/requirements.txt" in captured.err
+
+
+def test_serve_docs_uses_generated_html_directory(monkeypatch, capsys):
+    calls = {}
+
+    class FakeServer:
+        def __init__(self, address, handler_class):
+            calls["address"] = address
+            calls["handler_class"] = handler_class
+
+        def serve_forever(self):
+            return None
+
+        def server_close(self):
+            calls["closed"] = True
+
+    monkeypatch.setattr(preview_docs, "ThreadingHTTPServer", FakeServer)
+
+    preview_docs.serve_docs(8123)
+
+    assert calls["address"] == (preview_docs.DEFAULT_HOST, 8123)
+    assert calls["handler_class"].keywords["directory"] == str(preview_docs.BUILD_DIR)
+    assert calls["closed"] is True
+    captured = capsys.readouterr()
+    assert "http://127.0.0.1:8123/" in captured.out
+    assert str(preview_docs.BUILD_DIR) in captured.out
+
+
+def test_main_exits_before_serving_on_build_failure(monkeypatch):
+    served = {"called": False}
+
+    monkeypatch.setattr(preview_docs.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(preview_docs, "build_docs", lambda: 2)
+    monkeypatch.setattr(
+        preview_docs, "serve_docs", lambda port: served.__setitem__("called", True)
+    )
+
+    assert preview_docs.main([]) == 2
+    assert served["called"] is False
+
+
+def test_main_passes_custom_port_to_server(monkeypatch):
+    calls = {}
+
+    monkeypatch.setattr(preview_docs.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(preview_docs, "build_docs", lambda: 0)
+    monkeypatch.setattr(
+        preview_docs, "serve_docs", lambda port: calls.__setitem__("port", port)
+    )
+
+    assert preview_docs.main(["--port", "9001"]) == 0
+    assert calls["port"] == 9001


### PR DESCRIPTION
This change adds a `scripts/preview_docs.py`, helper that builds the Sphinx docs and  then serves `docs/_build/html` locally for browser preview. Also updates `CONTRIBUTING.md` with the docs setup and preview steps, and adds focused  test coverage plus the required ownership metadata updates.