### PR TITLE
Expose local files in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "TZ": "Etc/UTC",
     "POETRY_HOME": "/opt/poetry",
     "VIRTUAL_ENV": "/home/vscode/.venv",
-    "POETRY_VIRTUALENVS_CREATE": "false"
+    "POETRY_VIRTUALENVS_CREATE": "false",
+    "PYTHONPATH": "${containerWorkspaceFolder}"
   },
   "postCreateCommand": "git config --global --add safe.directory \"$(pwd)\" && poetry install --with dev --no-interaction",
   "customizations": {

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ devcontainer exec --workspace-folder . poetry run pytest -q
 
 The container installs project dependencies with Poetry and uses
 `/home/vscode/.venv`, so it does not reuse a host operating system's `.venv`.
-Poetry itself is kept in a separate `/opt/poetry` environment. Use the container
-for changes involving time zones, paths, native libraries, or other
-operating-system-dependent behavior. Standard Python 3.9 and Python 3.12
-installations remain covered by the existing CI matrix.
+Poetry itself is kept in a separate `/opt/poetry` environment. The workspace
+root is also added to `PYTHONPATH`, so the checked-out source and local test
+modules are available throughout a Codespace without copying them into the
+image. Use the container for changes involving time zones, paths, native
+libraries, or other operating-system-dependent behavior. Standard Python 3.9
+and Python 3.12 installations remain covered by the existing CI matrix.


### PR DESCRIPTION
## Summary

- add the mounted dev-container workspace root to `PYTHONPATH`
- make checked-out source and local test modules available throughout GitHub Codespaces
- document that the files remain live from the workspace instead of being copied into the image

## Why

The post-create Poetry install prepares the project and development dependencies, but processes started outside the repository working directory do not consistently discover repository-local source and test files. Exposing `${containerWorkspaceFolder}` through `PYTHONPATH` makes the local checkout available across the Codespace.

## Impact

Edits to source and test files are immediately reflected in Python processes anywhere in the dev container. Normal package installation and the existing virtual environment layout are unchanged.

## Validation

- clean dev-container creation, including the existing Poetry post-create install
- import/path check from `/tmp` confirmed `cwmscli` and `tests` resolve under `/workspaces/cwms-cli`
- `poetry run pytest -q` (373 passed)
- `poetry run pre-commit run --all-files`
