### PR TITLE
Run required docs check on every PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,6 @@ name: Docs Validation
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
-      - "cwmscli/**"
-      - "pyproject.toml"
-      - "scripts/**"
-      - "CONTRIBUTING.md"
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- run the Docs Validation workflow for every pull request
- retain the existing path filters for pushes to `main`

## Why

The `main - required checks` ruleset requires the `html` job for every pull request. The workflow's pull-request path filter prevented that job from starting when a change did not touch documentation, Python source, project metadata, scripts, or `CONTRIBUTING.md`. GitHub then left the required `html` context in an indefinitely expected state and blocked otherwise valid pull requests.

## Impact

Every pull request now reports the required `html` status. Scheduled behavior and path-filtered validation after pushes to `main` remain unchanged.

## Validation

- `actionlint -shellcheck= .github/workflows/docs.yml`
- commit-time `yamlfix` and generated ownership checks
- confirmed the unrestricted pull-request trigger matches the repository ruleset's unconditional `html` requirement

`actionlint` with ShellCheck enabled still reports the existing SC2129 style warning in the workflow summary step; the same warning is present on `origin/main` and is outside this fix.
